### PR TITLE
Fix environment variable test syntax

### DIFF
--- a/tests/example.spec.ts
+++ b/tests/example.spec.ts
@@ -21,4 +21,4 @@ test('environment variable test', async ({ page }) => {
   expect.soft(process.env.ENV_URL, 'env url is ok').toBe('https://playwright.dev/');
   expect.soft(process.env.USERID, 'userid is ok').toBe('dev.userid');
   expect.soft(process.env.PASSWORD, 'password is ok').toBe('dev.password');
-})
+});


### PR DESCRIPTION
## Summary
- add missing closing semicolon to environment variable test

## Testing
- `npx playwright test` *(fails: 403 Forbidden trying to reach registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6869340f427c83218b64c9364869e4f1